### PR TITLE
Fix links in queryover-series.md

### DIFF
--- a/queryover-series.md
+++ b/queryover-series.md
@@ -16,5 +16,5 @@ This is the index page for the blog post series on NHibernate's QueryOver API:
 6. [Query Building Techniques](../blog/2014/08/07/queryover-series-part-6-query-building-techniques/)
 7. [Using SQL Functions](../blog/2014/08/15/queryover-series-part-7-using-sql-functions)
 8. [Working with Subqueries](../blog/2014/10/24/queryover-series-part-8-working-with-subqueries/)
-9. [Extending QueryOver to Use Custom Methods and Properties](../blog/2015/01/28/queryover-series-part-9-extending-queryover-using-custom-methods-and-properties/)
-10. [Combining Criteria and QueryOver](../blog/2015/05/31/queryover-series-part-10-combining-criteria-and-queryover/)
+9. [Extending QueryOver to Use Custom Methods and Properties](../blog/2015/01/29/queryover-series-part-9-extending-queryover-using-custom-methods-and-properties/)
+10. [Combining Criteria and QueryOver](../blog/2015/06/01/queryover-series-part-10-combining-criteria-and-queryover/)


### PR DESCRIPTION
I believe the timezones in the respective markdown files cause the date to be flipped to the next day:

* date: 2015-01-28 19:05:39 -0600 => equals 2015-01-29 in UTC?
* date: 2015-05-31 19:43:08 -0500 => equals 2015-06-01 in UTC?

The links on https://www.andrewwhitaker.com/ (correct) differ from https://www.andrewwhitaker.com/queryover-series/